### PR TITLE
2020-12-09 DB: Added lfphp-get script to install libyaml

### DIFF
--- a/scripts/libyaml_LfPHP_setup.sh.txt
+++ b/scripts/libyaml_LfPHP_setup.sh.txt
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+export NAME="libyaml"
+export PKG="yaml-0.2.5"
+cd \tmp
+wget https://github.com/yaml/libyaml/releases/download/0.2.5/$PKG.tar.gz
+tar -xvf $PKG.tar.gz
+cd $PKG
+./configure prefix=/usr
+make
+make install
+cd \tmp
+rm -rf $PKG
+if [[ $? -gt 0 ]]; then
+  echo -e "\n$NAME Installation ERROR!  Aborting!\n"
+exit 1
+fi
+echo -e "\n$NAME Installation DONE!\n"
+cd


### PR DESCRIPTION
Once this is installed you can then install  which is a YAML extension that supports PHP 8:
`lfphp-get libyaml`
`lfphp-get php-ext yaml-2.2.0`
Tested using the example from https://www.php.net/manual/en/yaml.examples.php
Works as expected.