### PR TITLE
2021-02-05 DB: Updated phpmyadmin to 5.1.0 + added scripts

### DIFF
--- a/scripts/bison_LfPHP_setup.sh.txt
+++ b/scripts/bison_LfPHP_setup.sh.txt
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+export NAME="bison"
+export PKG="bison-2.6.5"
+cd \tmp
+wget http://gnu.mirror.iweb.com/bison/$PKG.tar.gz
+tar xvfz /tmp/$PKG.tar.gz
+cd $PKG
+./configure prefix=/usr
+make
+make install
+cd \tmp
+rm -rf $PKG
+if [[ $? -gt 0 ]]; then
+  echo -e "\n$NAME Installation ERROR!  Aborting!\n"
+exit 1
+fi
+echo -e "\n$NAME Installation DONE!\n"
+cd

--- a/scripts/kerberos_LfPHP_setup.sh.txt
+++ b/scripts/kerberos_LfPHP_setup.sh.txt
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+export NAME="kerberos"
+export PKG="krb5-1.18.3"
+cd \tmp
+wget http://web.mit.edu/kerberos/dist/krb5/1.18/$PKG.tar.gz
+tar xvfz /tmp/$PKG.tar.gz
+cd $PKG/src
+./configure prefix=/usr
+make
+make install
+cd \tmp
+rm -rf $PKG
+if [[ $? -gt 0 ]]; then
+  echo -e "\n$NAME Installation ERROR!  Aborting!\n"
+exit 1
+fi
+echo -e "\n$NAME Installation DONE!\n"
+cd

--- a/scripts/leptonica_LfPHP_setup.sh.txt
+++ b/scripts/leptonica_LfPHP_setup.sh.txt
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Usage: lfphp-get leptonica [--compile]
+# Example: lfphp-get leptonica --compile
+#
+# Includes the following conversion utilities:
+# /usr/local/bin/convertfilestopdf
+# /usr/local/bin/convertfilestops
+# /usr/local/bin/convertformat
+# /usr/local/bin/convertsegfilestopdf
+# /usr/local/bin/convertsegfilestops
+# /usr/local/bin/converttopdf
+# /usr/local/bin/converttops
+# /usr/local/bin/fileinfo
+# /usr/local/bin/imagetops
+# /usr/local/bin/xtractprotos
+# See: http://www.leptonica.org/
+#
+export COMPILE=0
+export flags=""
+export src_vers="1.80.0"
+export src_source="http://www.leptonica.org/source"
+# this needs to change!
+export bin_source="https://opensource.unlikelysource.com/leptonica.zip"
+if [[ ! -z "$1" ]]; then
+    if [[ "$1" = "--compile" ]]; then
+        COMPILE=1
+    fi
+fi
+if [[ "$COMPILE" -gt 0 ]]; then
+    cd /tmp
+    wget $src_source/leptonica-$src_vers.tar.gz
+    if [[ ! -f /tmp/leptonica-$src_vers.tar.gz ]]; then
+      echo -e "leptonica source code not found.  Aborting!"
+      echo ""
+      exit 1
+    fi
+    tar xvfz leptonica-$src_vers.tar.gz
+    cd /tmp/leptonica-$src_vers
+    ./autogen.sh
+    ./configure
+    make
+    make install
+    ldconfig
+    cd /tmp
+    rm /tmp/leptonica-$src_vers.tar.gz
+    rm -rf /tmp/leptonica-$src_vers
+    if [[ $? -gt 0 ]]; then
+      echo -e "leptonica Compilation ERROR!  Aborting!"
+    echo ""
+      exit 1
+    fi
+    echo "leptonica Compilation and Installation DONE!"
+    echo ""
+else
+    cd /
+    wget $bin_source/leptonica-$src_vers.zip
+    unzip -u -q leptonica-$src_vers.zip
+    rm leptonica-$src_vers.zip
+    echo "leptonica installation DONE!"
+    echo ""
+fi
+ls -l /usr/local/bin/convert*
+cd
+

--- a/scripts/libyaml_LfPHP_setup.sh.txt
+++ b/scripts/libyaml_LfPHP_setup.sh.txt
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+export NAME="libyaml"
+export PKG="yaml-0.2.5"
+cd \tmp
+wget https://github.com/yaml/libyaml/releases/download/0.2.5/$PKG.tar.gz
+tar -xvf $PKG.tar.gz
+cd $PKG
+./configure prefix=/usr
+make
+make install
+cd \tmp
+rm -rf $PKG
+if [[ $? -gt 0 ]]; then
+  echo -e "\n$NAME Installation ERROR!  Aborting!\n"
+exit 1
+fi
+echo -e "\n$NAME Installation DONE!\n"
+cd

--- a/scripts/phpmyadmin_LfPHP_setup.sh.txt
+++ b/scripts/phpmyadmin_LfPHP_setup.sh.txt
@@ -1,46 +1,28 @@
 #!/usr/bin/env bash
-cd &&
-wget -O phpMyAdmin-5.0.4-all-languages.tar.gz https://files.phpmyadmin.net/phpMyAdmin/5.0.4/phpMyAdmin-5.0.4-all-languages.tar.gz &&
-tar -xvf phpMyAdmin-5.0.4-all-languages.tar.gz &&
-cp -rf phpMyAdmin-5.0.4-all-languages /srv/phpmyadmin &&
-rm -rf phpMyAdmin-5.0.4-all-languages &&
-cat >/etc/httpd/extra/httpd-phpmyadmin.conf << 'EOF' &&
+# Usage: phpmyadmin_install.sh VERSION
+if [[ -z "$1" ]]; then
+    export VER=5.1.0
+else
+    export VER=$1
+fi
+cd /tmp
+wget -O phpMyAdmin-$VER-all-languages.tar.gz https://files.phpmyadmin.net/phpMyAdmin/$VER/phpMyAdmin-$VER-all-languages.tar.gz
+tar -xvf phpMyAdmin-$VER-all-languages.tar.gz
+mkdir -p /srv/phpmyadmin
+cp -rf phpMyAdmin-$VER-all-languages/* /srv/phpmyadmin
+rm -rf phpMyAdmin-$VER-all-languages
+cat >/etc/httpd/extra/httpd-phpmyadmin.conf << 'EOF'
 Alias /phpmyadmin /srv/phpmyadmin
-
 <Directory "/srv/phpmyadmin">
-    #
-    # Possible values for the Options directive are "None", "All",
-    # or any combination of:
-    #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI
-    #   MultiViews
-    #
-    # Note that "MultiViews" must be named *explicitly* --- "Options
-    # All"
-    # doesn't give it to you.
-    #
-    # The Options directive is both complicated and important.  Please
-    # see
     # http://httpd.apache.org/docs/2.4/mod/core.html#options
     # for more information.
-    #
     Options Indexes FollowSymLinks
-
-    #
-    # AllowOverride controls what directives may be placed in .htaccess
-    # files.
-    # It can be "All", "None", or any combination of the keywords:
-    #   AllowOverride FileInfo AuthConfig Limit
-    #
     AllowOverride All
-
-    #
-    # Controls who can get stuff from this server.
-    #
     Require all granted
 </Directory>
 EOF
-echo 'Include /etc/httpd/extra/httpd-phpmyadmin.conf' >> /etc/httpd/httpd.conf &&
-cp /srv/phpmyadmin/config.sample.inc.php /srv/phpmyadmin/config.inc.php &&
+echo 'Include /etc/httpd/extra/httpd-phpmyadmin.conf' >> /etc/httpd/httpd.conf
+cp /srv/phpmyadmin/config.sample.inc.php /srv/phpmyadmin/config.inc.php
 sed -i "s/AllowNoPassword'] = false;/AllowNoPassword'] = true;/" /srv/phpmyadmin/config.inc.php
 echo "Setting apache as owner ..."
 chown -v apache:apache /srv/phpmyadmin
@@ -48,8 +30,8 @@ echo "Configuring blowfish secret in /srv/phpmyadmin/config.inc.php ... "
 export SECRET=`php -r "echo md5(date('Y-m-d-H-i-s') . rand(1000,9999));"`
 echo "\$cfg['blowfish_secret'] = '$SECRET';" >> /srv/phpmyadmin/config.inc.php
 if [[ $? -gt 0 ]]; then
-echo -e "\nphpMyAdmin Installation ERROR!  Aborting!\n"
-exit 1
+    echo -e "\nphpMyAdmin Installation ERROR!  Aborting!\n"
+    exit 1
 fi
 /etc/init.d/mysql restart
 /etc/init.d/php-fpm restart

--- a/scripts/phpmyadmin_LfPHP_setup.sh.txt
+++ b/scripts/phpmyadmin_LfPHP_setup.sh.txt
@@ -42,6 +42,11 @@ EOF
 echo 'Include /etc/httpd/extra/httpd-phpmyadmin.conf' >> /etc/httpd/httpd.conf &&
 cp /srv/phpmyadmin/config.sample.inc.php /srv/phpmyadmin/config.inc.php &&
 sed -i "s/AllowNoPassword'] = false;/AllowNoPassword'] = true;/" /srv/phpmyadmin/config.inc.php
+echo "Setting apache as owner ..."
+chown -v apache:apache /srv/phpmyadmin
+echo "Configuring blowfish secret in /srv/phpmyadmin/config.inc.php ... "
+export SECRET=`php -r "echo md5(date('Y-m-d-H-i-s') . rand(1000,9999));"`
+echo "\$cfg['blowfish_secret'] = '$SECRET';" >> /srv/phpmyadmin/config.inc.php
 if [[ $? -gt 0 ]]; then
 echo -e "\nphpMyAdmin Installation ERROR!  Aborting!\n"
 exit 1

--- a/scripts/phpmyadmin_LfPHP_setup.sh.txt
+++ b/scripts/phpmyadmin_LfPHP_setup.sh.txt
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 cd &&
-wget -O phpMyAdmin-5.0.2-all-languages.tar.gz https://files.phpmyadmin.net/phpMyAdmin/5.0.2/phpMyAdmin-5.0.2-all-languages.tar.gz &&
-tar -xvf phpMyAdmin-5.0.2-all-languages.tar.gz &&
-cp -rf phpMyAdmin-5.0.2-all-languages /srv/phpmyadmin &&
-rm -rf phpMyAdmin-5.0.2-all-languages &&
+wget -O phpMyAdmin-5.0.4-all-languages.tar.gz https://files.phpmyadmin.net/phpMyAdmin/5.0.4/phpMyAdmin-5.0.4-all-languages.tar.gz &&
+tar -xvf phpMyAdmin-5.0.4-all-languages.tar.gz &&
+cp -rf phpMyAdmin-5.0.4-all-languages /srv/phpmyadmin &&
+rm -rf phpMyAdmin-5.0.4-all-languages &&
 cat >/etc/httpd/extra/httpd-phpmyadmin.conf << 'EOF' &&
 Alias /phpmyadmin /srv/phpmyadmin
 


### PR DESCRIPTION
Updated phpmyadmin to 5.0.4 + added scripts for bison, kerberos and leptonica libraries + utilities
## phpmyadmin
* Updated to 5.0.4
* Added scripting to automatically populate `$cfg['blowfish_secret']`
## bison
* Needed by the PHP mongodb extension (among others)
## kerberos
* Goes without saying!
## leptonica
* This is a requirement for the Tessaract OCR engine library
* Will do that later!
* Includes lots of really cool and useful utilities:
```
# /usr/local/bin/convertfilestopdf
# /usr/local/bin/convertfilestops
# /usr/local/bin/convertformat
# /usr/local/bin/convertsegfilestopdf
# /usr/local/bin/convertsegfilestops
# /usr/local/bin/converttopdf
# /usr/local/bin/converttops
# /usr/local/bin/fileinfo
# /usr/local/bin/imagetops
# /usr/local/bin/xtractprotos
# See: http://www.leptonica.org/
```